### PR TITLE
Update Readme to reflect renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This implementation is not supported, endorsed, or created by Valve - I'm just a
 
 ## Usage
 
-    var steam = require('steam');
+    var steam = require('steam-web');
 
     var s = new steam({
       apiKey: 'XXXXXXXXXXXXXXXX',


### PR DESCRIPTION
I think it should say `require('steam-web')` instead of `require('steam')` in the readme.
(At least that's how I managed to get it working...)  
