### PR TITLE
JSON format wrong API key handling

### DIFF
--- a/lib/steam.js
+++ b/lib/steam.js
@@ -207,7 +207,14 @@ steam.prototype.makeRequest = function(obj) {
         callback('invalid API key');
         return;
       }
-      if (format == 'json') resData = JSON.parse(resData);
+      if (format == 'json') {
+        try {
+          resData = JSON.parse(resData);
+        } catch (e) {
+          callback('JSON response invalid, your API key is most likely wrong');
+          return;
+        }
+      }
       
       if (  typeof resData.result != 'undefined' && 
             typeof resData.result.status != 'undefined' &&


### PR DESCRIPTION
When using an invalid API key with the json format, the steam API won't return a json response and will simply display regular HTML, this commit prevents node.js from crashing and actually calls the callback with an error when this situation happens.